### PR TITLE
ci: gate Angular tests + fix TripCatchComponent spec

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-# This workflow will build a .NET project
+# This workflow will build a .NET project and run Angular unit tests.
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: build
@@ -7,9 +7,7 @@ on:
   workflow_dispatch:
   workflow_call:
   push:
-    branches-ignore: master    
-  # pull_request:
-  #   branches: [ "master" ]
+    branches-ignore: master
 
 jobs:
   build:
@@ -32,30 +30,24 @@ jobs:
         run: dotnet build --no-restore
       - name: Test
         run: dotnet test --no-build --verbosity normal
-      # - name: Debug output
-      #   run: ls src/FishTrackerLambda/bin/Debug/net6.0
-      # - name: Create output
-      #   run: mkdir output
-      # - name: Create lambda-deploymentpackage.zip
-      #   run: zip -r -j output/lambda-deploymentpackage.zip src/FishTrackerLambda/bin/Debug/net6.0/*
-      # - name: Current Directory
-      #   run: pwd
-      # - name: contents Current Directory
-      #   run: ls
-      # - name: Debug output
-      #   run: ls output
 
-      # - name: Setup Node.js
-      #   uses: actions/setup-node@v2
-      #   with:
-      #     node-version: 18
-  
-      # - name: Install dependencies
-      #   run: npm install
-      #   working-directory: web
-  
-      # - name: Run tests
-      #   run: npm run test:headless
-      #   working-directory: web
+  test-angular:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: angular
 
-          
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: angular/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm run test:headless

--- a/angular/src/app/pages/trip-catch/trip-catch.component.spec.ts
+++ b/angular/src/app/pages/trip-catch/trip-catch.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
 
 import { TripCatchComponent } from './trip-catch.component';
 
@@ -8,7 +10,16 @@ describe('TripCatchComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TripCatchComponent]
+      imports: [TripCatchComponent],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            paramMap: of(new Map()),
+            snapshot: { paramMap: { get: () => null } },
+          },
+        },
+      ],
     })
     .compileComponents();
 


### PR DESCRIPTION
Adds a test-angular job to build.yml that runs Karma headless. Also fixes TripCatchComponent spec by providing a stub ActivatedRoute — the component reads from route params at construction, and the TestBed wasn't supplying one, causing NG0201.

All 33 Angular specs now pass.